### PR TITLE
Fix Multiplayer Bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ data_*/
 mono_crash.*.json
 
 # Visual Studio ignores
-.vs
+.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ export_presets.cfg
 .mono/
 data_*/
 mono_crash.*.json
+
+# Visual Studio ignores
+.vs

--- a/First Game/Properties/launchSettings.json
+++ b/First Game/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Debug": {
+      "commandName": "Executable",
+      "executablePath": "%GODOT%",
+      "workingDirectory": ".",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/First Game/Scripts/Multiplayer/MultiplayerController.cs
+++ b/First Game/Scripts/Multiplayer/MultiplayerController.cs
@@ -30,7 +30,7 @@ public partial class MultiplayerController : CharacterBody2D
     public bool Alive { get; private set; } = true;
 
     private int _playerId = 1;
-    public int PlayerId
+    [Export] public int PlayerId
     {
         get => _playerId;
         set

--- a/First Game/Scripts/Multiplayer/MultiplayerController.cs
+++ b/First Game/Scripts/Multiplayer/MultiplayerController.cs
@@ -24,14 +24,26 @@ public partial class MultiplayerController : CharacterBody2D
     private CollisionShape2D _collisionShape2D = default!;
     private Timer _respawnTimer = default!;
 
-    private bool _isReady;
-
     public float Direction { get; private set; } = 1;
     public bool OnFloor { get; private set; } = true;
     public bool DoJump { get; set; }
     public bool Alive { get; private set; } = true;
 
-    [Export] public int PlayerId { get; set; } = 1;
+    private int _playerId = 1;
+    public int PlayerId
+    {
+        get => _playerId;
+        set
+        {
+            _playerId = value;
+
+            if (_inputSynchronizer is null)
+            {
+                _inputSynchronizer = this.GetNodeOrThrow<MultiplayerInput>("%InputSynchronizer");
+            }
+            _inputSynchronizer.SetMultiplayerAuthority(value);
+        }
+    }
 
     public override void _Ready()
     {
@@ -39,12 +51,10 @@ public partial class MultiplayerController : CharacterBody2D
 
         _animatedSprite = this.GetNodeOrThrow<AnimatedSprite2D>(nameof(AnimatedSprite2D));
         _gravity = ProjectSettings.GetSetting("physics/2d/default_gravity").AsSingle();
-        _inputSynchronizer = this.GetNodeOrThrow<MultiplayerInput>("%InputSynchronizer");
+        _inputSynchronizer ??= this.GetNodeOrThrow<MultiplayerInput>("%InputSynchronizer");
         _camera2D = this.GetNodeOrThrow<Camera2D>(nameof(Camera2D));
         _collisionShape2D = this.GetNodeOrThrow<CollisionShape2D>(nameof(CollisionShape2D));
         _respawnTimer = this.GetNodeOrThrow<Timer>("RespawnTimer");
-
-        _inputSynchronizer.SetMultiplayerAuthority(PlayerId);
 
         if (Multiplayer.GetUniqueId() == PlayerId)
         {
@@ -54,8 +64,6 @@ public partial class MultiplayerController : CharacterBody2D
         {
             _camera2D.Enabled = false;
         }
-
-        _isReady = true;
     }
 
     public override void _PhysicsProcess(double delta)

--- a/First Game/scenes/multiplayer_player.tscn
+++ b/First Game/scenes/multiplayer_player.tscn
@@ -11,13 +11,13 @@ properties/0/replication_mode = 1
 properties/1/path = NodePath(".:position")
 properties/1/spawn = true
 properties/1/replication_mode = 1
-properties/2/path = NodePath("MultiplayerPlayer:OnFloor")
+properties/2/path = NodePath(".:OnFloor")
 properties/2/spawn = true
 properties/2/replication_mode = 1
-properties/3/path = NodePath("MultiplayerPlayer:Direction")
+properties/3/path = NodePath(".:Direction")
 properties/3/spawn = true
 properties/3/replication_mode = 1
-properties/4/path = NodePath("MultiplayerPlayer:DoJump")
+properties/4/path = NodePath(".:DoJump")
 properties/4/spawn = true
 properties/4/replication_mode = 1
 

--- a/README.md
+++ b/README.md
@@ -7,29 +7,13 @@ Uses MultiplayerSynchronizer, MultiplayerSpawner, and RPCs to sync player positi
 - Multiplayer tutorial (GDScript): https://youtu.be/V4a_J38XdHk
 - Brackeys tutorial (GDScript): https://www.youtube.com/watch?v=LOhfqjmasi0
 
-## C# Porting Progress
-> This example is in progress and does not currently work as intended. See below for details on the remaining issue to be fixed.
+### Local Testing
 
-### Repro Steps
-
-> If debugging from VS Code/Codium, change the `launch.json` as needed for your IDE, making sure it points to the local install of Godot 4.4.1. I only added VS Codium setup and use the GODOT environment variable to point to my local install.
-
-- Clone and open the project for editing in Godot Mono 4.4.1.
 - In the editor, go to Debug > "Customize Run Instances..."
   - Enable Multiple Instances should be checked.
-  - Change the number of instances to 2 (or higher if desired).
+  - Change the number of instances to 2.
   - Click the "OK" button.
 - Run the project.
 - From one of the instances, click "Host New Game".
 - From another instance, click "Join as Player 2".
-- BUG: It isn't working as expected. Observe the following:
-  - The Player 2 instance has no players spawned in the "Players" node. There may or may not be errors in the debug log as shown below.
-    - ![Player2Instance.png](https://github.com/bclewi/brackeys-godot-csharp.first-game-in-godot/blob/main/screenshots/Player2Instance.png?raw=true)
-  - The Player 2 Game Window has no player with an active camera and shows the level zoomed out.
-    - ![Player2InstanceGameWindow.png](https://github.com/bclewi/brackeys-godot-csharp.first-game-in-godot/blob/main/screenshots/Player2InstanceGameWindow.png?raw=true)
-  - The Host instance is unable to synchronize with other instances and throws many errors in the debug log as shown below.
-    - ![HostInstance1.png](https://github.com/bclewi/brackeys-godot-csharp.first-game-in-godot/blob/main/screenshots/HostInstance1.png?raw=true)
-     - ![HostInstance2.png](https://github.com/bclewi/brackeys-godot-csharp.first-game-in-godot/blob/main/screenshots/HostInstance2.png?raw=true)
-  - Both the Host an the Player 2 move with the same inputs in the Host Game Window.
-    - ![HostInstanceGameWindow.png](https://github.com/bclewi/brackeys-godot-csharp.first-game-in-godot/blob/main/screenshots/HostInstanceGameWindow.png?raw=true)
 


### PR DESCRIPTION
- Fixed the Property Paths for MultiplayerSynchronizer (temporarily adding `[Export]` can help with this).
- Moved the call to `_inputSynchronizer.SetMultiplayerAuthority()` to the PlayerId setter in MultiplayerController.
  - Get `_inputSynchronizer` if needed in the setter (first call is prior to `_Ready`).
- Add launch profile for Visual Studio (assumes the `GODOT` environment variable is set).